### PR TITLE
Add per degree  channel power target out

### DIFF
--- a/gnpy/core/elements.py
+++ b/gnpy/core/elements.py
@@ -184,17 +184,20 @@ class Transceiver(_Node):
         return spectral_info
 
 
-RoadmParams = namedtuple('RoadmParams', 'target_pch_out_db add_drop_osnr pmd restrictions')
+RoadmParams = namedtuple('RoadmParams', 'target_pch_out_db add_drop_osnr pmd restrictions per_degree_params')
 
 
 class Roadm(_Node):
     def __init__(self, *args, params, **kwargs):
+        if 'per_degree_params' not in params.keys():
+            params['per_degree_params'] = []
         super().__init__(*args, params=RoadmParams(**params), **kwargs)
         self.loss = 0  # auto-design interest
         self.effective_loss = None
         self.effective_pch_out_db = self.params.target_pch_out_db
         self.passive = True
         self.restrictions = self.params.restrictions
+        self.per_degree_params = self.params.per_degree_params
 
     @property
     def to_json(self):
@@ -202,8 +205,9 @@ class Roadm(_Node):
                 'type': type(self).__name__,
                 'params': {
                     'target_pch_out_db': self.effective_pch_out_db,
-                    'restrictions': self.restrictions
-                },
+                    'restrictions': self.restrictions,
+                    'per_degree_params': self.per_degree_params
+                    },
                 'metadata': {
                     'location': self.metadata['location']._asdict()
                 }
@@ -220,15 +224,23 @@ class Roadm(_Node):
                           f'  effective loss (dB):  {self.effective_loss:.2f}',
                           f'  pch out (dBm):        {self.effective_pch_out_db!r}'])
 
-    def propagate(self, pref, *carriers):
+    def propagate(self, pref, *carriers, degree):
         # pin_target and loss are read from eqpt_config.json['Roadm']
         # all ingress channels in xpress are set to this power level
         # but add channels are not, so we define an effective loss
         # in the case of add channels
-        self.effective_pch_out_db = min(pref.p_spani, self.params.target_pch_out_db)
+        roadm_degree = {el['to_node']: el['target_pch_out_db'] for el in self.per_degree_params
+                        if 'target_pch_out_db' in el.keys()} if self.per_degree_params else {}
+        # find the target power on this degree:
+        # if a target power has been defined for this degree use it else use the global one
+        # if result of signal propagation before ROADM (pref.p_spani) is smaller than target power,
+        # then use this one... Which is not really meaningfull, but is a very unprobable situation:
+        # TODO maybe add a minimum loss for the ROADM
+        temp = roadm_degree[degree] if degree in roadm_degree.keys() else self.params.target_pch_out_db
+        self.effective_pch_out_db = min(pref.p_spani, temp)
         self.effective_loss = pref.p_spani - self.effective_pch_out_db
         carriers_power = array([c.power.signal + c.power.nli + c.power.ase for c in carriers])
-        carriers_att = list(map(lambda x: lin2db(x * 1e3) - self.params.target_pch_out_db, carriers_power))
+        carriers_att = list(map(lambda x: lin2db(x * 1e3) - self.effective_pch_out_db, carriers_power))
         exceeding_att = -min(list(filter(lambda x: x < 0, carriers_att)), default=0)
         carriers_att = list(map(lambda x: db2lin(x + exceeding_att), carriers_att))
         for carrier_att, carrier in zip(carriers_att, carriers):
@@ -242,8 +254,8 @@ class Roadm(_Node):
     def update_pref(self, pref):
         return pref._replace(p_span0=pref.p_span0, p_spani=self.effective_pch_out_db)
 
-    def __call__(self, spectral_info):
-        carriers = tuple(self.propagate(spectral_info.pref, *spectral_info.carriers))
+    def __call__(self, spectral_info, degree):
+        carriers = tuple(self.propagate(spectral_info.pref, *spectral_info.carriers, degree=degree))
         pref = self.update_pref(spectral_info.pref)
         return spectral_info._replace(carriers=carriers, pref=pref)
 

--- a/gnpy/topology/request.py
+++ b/gnpy/topology/request.py
@@ -333,8 +333,11 @@ def propagate(path, req, equipment):
     si = create_input_spectral_information(
         req.f_min, req.f_max, req.roll_off, req.baud_rate,
         req.power, req.spacing)
-    for el in path:
-        si = el(si)
+    for i, el in enumerate(path):
+        if isinstance(el, Roadm):
+            si = el(si, degree=path[i+1].uid)
+        else:
+            si = el(si)
     path[0].update_snr(req.tx_osnr)
     if any(isinstance(el, Roadm) for el in path):
         path[-1].update_snr(req.tx_osnr, equipment['Roadm']['default'].add_drop_osnr)
@@ -366,8 +369,11 @@ def propagate_and_optimize_mode(path, req, equipment):
             spc_info = create_input_spectral_information(req.f_min, req.f_max,
                                                          equipment['SI']['default'].roll_off,
                                                          this_br, req.power, req.spacing)
-            for el in path:
-                spc_info = el(spc_info)
+            for i, el in enumerate(path):
+                if isinstance(el, Roadm):
+                    spc_info = el(spc_info, degree=path[i+1].uid)
+                else:
+                    spc_info = el(spc_info)
             for this_mode in modes_to_explore:
                 if path[-1].snr is not None:
                     path[0].update_snr(this_mode['tx_osnr'])

--- a/tests/data/testTopology_auto_design_expected.json
+++ b/tests/data/testTopology_auto_design_expected.json
@@ -164,7 +164,21 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "east edfa in Lannion_CAS to Corlay",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "east edfa in Lannion_CAS to Stbrieuc",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "east edfa in Lannion_CAS to Morlaix",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -183,7 +197,21 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm Lorient_KMA",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm Lorient_KMA",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa2_roadm Lorient_KMA",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -202,7 +230,17 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm Vannes_KBE",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm Vannes_KBE",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -221,7 +259,17 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm Rennes_STA",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm Rennes_STA",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -240,7 +288,17 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "east edfa in Brest_KLA to Quimper",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa0_roadm Brest_KLA",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -259,7 +317,21 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "east edfa in c to d",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa0_roadm c",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm c",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -278,7 +350,17 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm d",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm d",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -297,7 +379,17 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm e",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm e",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -316,7 +408,21 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm f",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm f",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa2_roadm f",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -335,7 +441,17 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm g",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm g",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -354,7 +470,17 @@
         "restrictions": {
           "preamp_variety_list": [],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm h",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm h",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -375,7 +501,17 @@
           "booster_variety_list": [
             "std_booster"
           ]
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm a",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm a",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {
@@ -396,7 +532,17 @@
             "std_low_gain"
           ],
           "booster_variety_list": []
-        }
+        },
+        "per_degree_params": [
+          {
+            "to_node": "Edfa0_roadm b",
+            "target_pch_out_db": -20
+          },
+          {
+            "to_node": "Edfa1_roadm b",
+            "target_pch_out_db": -20
+          }
+        ]
       },
       "metadata": {
         "location": {


### PR DESCRIPTION
- add the per degree info using the EXACT next node uid as identifier
  of the degree when a node is a roadm
- add the degree identifier on the propagate and on the call functions
- use the per degree target_pch_out_db defined in json entry for the
  target power in network build
- verifies existence of the per degree power target in order to support
  partial per degree target power definition
- correct test data files for expected auto design results that now
  should include the per degree information, even if it is the same
  for all degree.

Signed-off-by: EstherLerouzic <esther.lerouzic@orange.com>
Change-Id: I5004cbb250ca5fd6b6498ac9d4b9c4f28a65efee